### PR TITLE
fix: Updated CFN template to use parameter store

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Just a place to put a couple of AWS CloudFormation templates for reference
 
 - `simpleEC2Instance.template.yaml` - creates an EC2 instance but assumes a keypair called `AWSAmbassadorKeypair` is available
-- `simpleEC2Instancewithkeypair.template.yaml` - creates an EC2 instance and its own keypair. Note: The private key will be avaialble in AWS SSM Parameter Store
+- `simpleEC2Instancewithkeypair.template.yaml` - creates an EC2 instance and its own keypair. Note: The private key will be available in AWS SSM Parameter Store

--- a/simpleEC2Instance.template.yaml
+++ b/simpleEC2Instance.template.yaml
@@ -2,6 +2,12 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: "A very simple EC2 instance and its keypair (in SSM)"
 Metadata:
   License: MIT-License
+
+Parameters:
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2'
+
 Resources:
   iamPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -75,7 +81,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       KeyName: AWSAmbassadorKeypair
-      ImageId: ami-03ad0a83902d7df88
+      ImageId: !Ref LatestAmiId
       InstanceType: c6g.medium
       IamInstanceProfile: !Ref iamInstanceProfile
       Monitoring: true

--- a/simpleEC2Instancewithkeypair.template.yaml
+++ b/simpleEC2Instancewithkeypair.template.yaml
@@ -2,6 +2,12 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: "A very simple EC2 instance that creates its own keypair"
 Metadata:
   License: MIT-License
+
+Parameters:
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2'
+
 Resources:
   AWSAmbassadorKeypair:
     Type: AWS::EC2::KeyPair
@@ -91,7 +97,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       KeyName: !Ref AWSAmbassadorKeypair
-      ImageId: ami-03ad0a83902d7df88
+      ImageId: !Ref LatestAmiId
       InstanceType: c6g.medium
       IamInstanceProfile: !Ref iamInstanceProfile
       Monitoring: true


### PR DESCRIPTION
# Description

Updated the CFN template to use the parameter store to reference the latest arm64 image id for amazonlinux2